### PR TITLE
Update docker-compose version for 3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
     nginx:
         image: nginx


### PR DESCRIPTION
Custom names were only allowed from version 3.5 above (according to the link https://docs.docker.com/compose/compose-file/compose-file-v3/#network-configuration-reference). The version that is in the original file will trigger a custom network name error.